### PR TITLE
Add Versioned2, Versioned3, and Versioned4 type definitions

### DIFF
--- a/protocol/serialization-types/src/account.rs
+++ b/protocol/serialization-types/src/account.rs
@@ -10,7 +10,7 @@ use crate::{
     v1::{AccountNonceV1, AmountV1, BlockTimeV1, HashV1, PublicKey2V1, PublicKeyV1, TokenIdV1},
 };
 use serde::{Deserialize, Serialize};
-use versioned::Versioned;
+use versioned::{Versioned, Versioned2, Versioned3};
 
 /// An account as is serialized into the Mina ledger database stores
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -41,7 +41,7 @@ pub struct Account {
 }
 
 /// An account as is serialized into the Mina ledger database stores (v1)
-pub type AccountV1 = Versioned<Versioned<Versioned<Account, 1>, 1>, 1>;
+pub type AccountV1 = Versioned3<Account, 1, 1, 1>;
 
 /// An account as is serialized into the Mina ledger database stores (unversioned)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -91,7 +91,7 @@ pub enum TokenPermissions {
 }
 
 ///
-pub type TokenPermissionsV1 = Versioned<Versioned<TokenPermissions, 1>, 1>;
+pub type TokenPermissionsV1 = Versioned2<TokenPermissions, 1, 1>;
 
 /// Permissions associated with the account
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -140,7 +140,7 @@ pub struct Permissions {
 }
 
 /// Permissions associated with the account (v1)
-pub type PermissionsV1 = Versioned<Versioned<PermissionsLegacy, 1>, 1>;
+pub type PermissionsV1 = Versioned2<PermissionsLegacy, 1, 1>;
 
 /// The level of auth required to perform a particular action with an account
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -218,4 +218,4 @@ pub struct TimedDataV0 {
 pub type TimedDataV1 = Versioned<TimedData, 1>;
 
 /// Timing information for an account with regard to when its balance is accessable (v1)
-pub type TimingV1 = Versioned<Versioned<Timing, 1>, 1>;
+pub type TimingV1 = Versioned2<Timing, 1, 1>;

--- a/protocol/serialization-types/src/blockchain_state.rs
+++ b/protocol/serialization-types/src/blockchain_state.rs
@@ -8,7 +8,7 @@
 use crate::common::*;
 use mina_serialization_types_macros::AutoFrom;
 use serde::{Deserialize, Serialize};
-use versioned::Versioned;
+use versioned::{Versioned, Versioned2};
 
 /// Mina blockchain state struct
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -26,7 +26,7 @@ pub struct BlockchainState {
 }
 
 /// Mina blockchain state struct (v1)
-pub type BlockchainStateV1 = Versioned<Versioned<BlockchainState, 1>, 1>;
+pub type BlockchainStateV1 = Versioned2<BlockchainState, 1, 1>;
 
 /// Mina blockchain state struct (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
@@ -52,7 +52,7 @@ pub struct StagedLedgerHash {
 }
 
 /// Staged ledger hash structure (v1)
-pub type StagedLedgerHashV1 = Versioned<Versioned<StagedLedgerHash, 1>, 1>;
+pub type StagedLedgerHashV1 = Versioned2<StagedLedgerHash, 1, 1>;
 
 /// Staged ledger hash structure (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/bulletproof_challenges.rs
+++ b/protocol/serialization-types/src/bulletproof_challenges.rs
@@ -72,8 +72,7 @@ pub struct BulletproofChallengeTuple17(
     pub (),
 );
 
-pub type BulletproofChallengeTuple17V1 =
-    Versioned<Versioned<Versioned<BulletproofChallengeTuple17, 1>, 1>, 1>;
+pub type BulletproofChallengeTuple17V1 = Versioned3<BulletproofChallengeTuple17, 1, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(BulletproofChallengeTuple17)]
@@ -122,7 +121,7 @@ pub struct BulletproofChallengeTuple18(
     pub (),
 );
 
-pub type BulletproofChallengeTuple18V1 = Versioned<Versioned<BulletproofChallengeTuple18, 1>, 1>;
+pub type BulletproofChallengeTuple18V1 = Versioned2<BulletproofChallengeTuple18, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(BulletproofChallengeTuple18)]

--- a/protocol/serialization-types/src/common.rs
+++ b/protocol/serialization-types/src/common.rs
@@ -18,14 +18,14 @@ pub type HashV1 = Versioned<[u8; 32], 1>;
 pub type Hash2V1 = Versioned<HashV1, 1>;
 
 /// u64 representing a token ID (v1)
-pub type TokenIdV1 = Versioned<Versioned<Versioned<u64, 1>, 1>, 1>;
+pub type TokenIdV1 = Versioned3<u64, 1, 1, 1>;
 impl_from_for_newtype!(U64Json, TokenIdV1);
 
 /// u64 representing a block time (v1)
-pub type BlockTimeV1 = Versioned<Versioned<u64, 1>, 1>;
+pub type BlockTimeV1 = Versioned2<u64, 1, 1>;
 
 /// u64 representing an account nonce (v1) // This should also be an extendedu32
-pub type AccountNonceV1 = Versioned<Versioned<u32, 1>, 1>;
+pub type AccountNonceV1 = Versioned2<u32, 1, 1>;
 
 /// u32 wrapper (json)
 /// Note that integers are represented as string in mina json
@@ -134,17 +134,17 @@ impl<'de> Deserialize<'de> for DecimalJson {
 }
 
 /// u32 representing a length (v1)
-pub type LengthV1 = Versioned<Versioned<u32, 1>, 1>;
+pub type LengthV1 = Versioned2<u32, 1, 1>;
 impl_from_for_newtype!(U32Json, LengthV1);
 
 /// u32 representing a delta (i.e. difference) (v1)
-pub type DeltaV1 = Versioned<Versioned<u32, 1>, 1>;
+pub type DeltaV1 = Versioned2<u32, 1, 1>;
 
 /// u32 representing a slot number (v1)
-pub type GlobalSlotNumberV1 = Versioned<Versioned<u32, 1>, 1>;
+pub type GlobalSlotNumberV1 = Versioned2<u32, 1, 1>;
 
 /// u64 representing an amount of currency (v1)
-pub type AmountV1 = Versioned<Versioned<u64, 1>, 1>;
+pub type AmountV1 = Versioned2<u64, 1, 1>;
 impl_from_for_newtype!(U64Json, AmountV1);
 impl_from_for_newtype!(DecimalJson, AmountV1);
 
@@ -152,7 +152,7 @@ impl_from_for_newtype!(DecimalJson, AmountV1);
 // Note: Extended_Uint32 is not defined in bin_prot, but comes from mina
 // Block path: t/staged_ledger_diff/t/diff/t/0/t/t/commands/0/t/data/t/t/t/t/payload/t/t/common/t/t/t/valid_until
 /// u32 wrapped in 1 version byte
-pub type ExtendedU32 = Versioned<Versioned<i32, 1>, 1>;
+pub type ExtendedU32 = Versioned2<i32, 1, 1>;
 impl From<U32Json> for ExtendedU32 {
     fn from(t: U32Json) -> Self {
         (t.0 as i32).into()

--- a/protocol/serialization-types/src/consensus_state.rs
+++ b/protocol/serialization-types/src/consensus_state.rs
@@ -128,7 +128,7 @@ pub struct ConsensusState {
 }
 
 /// V1 protocol version of the consensus state
-pub type ConsensusStateV1 = Versioned<Versioned<ConsensusState, 1>, 1>;
+pub type ConsensusStateV1 = Versioned2<ConsensusState, 1, 1>;
 
 /// json protocol version of the consensus state
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/epoch_data.rs
+++ b/protocol/serialization-types/src/epoch_data.rs
@@ -23,7 +23,7 @@ pub struct EpochLedger {
 }
 
 /// Epoch Ledger (v1)
-pub type EpochLedgerV1 = Versioned<Versioned<EpochLedger, 1>, 1>;
+pub type EpochLedgerV1 = Versioned2<EpochLedger, 1, 1>;
 
 /// Epoch Ledger (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
@@ -51,7 +51,7 @@ pub struct EpochData {
 }
 
 /// Epoch data (v1)
-pub type EpochDataV1 = Versioned<Versioned<EpochData, 1>, 1>;
+pub type EpochDataV1 = Versioned2<EpochData, 1, 1>;
 
 /// Epoch data (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/global_slot.rs
+++ b/protocol/serialization-types/src/global_slot.rs
@@ -5,7 +5,7 @@
 
 use mina_serialization_types_macros::AutoFrom;
 use serde::{Deserialize, Serialize};
-use versioned::Versioned;
+use versioned::Versioned2;
 
 use crate::{
     common::U32Json,
@@ -22,7 +22,7 @@ pub struct GlobalSlot {
 }
 
 /// A global slot (v1)
-pub type GlobalSlotV1 = Versioned<Versioned<GlobalSlot, 1>, 1>;
+pub type GlobalSlotV1 = Versioned2<GlobalSlot, 1, 1>;
 
 /// A global slot (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/proof_messages.rs
+++ b/protocol/serialization-types/src/proof_messages.rs
@@ -8,7 +8,7 @@
 use crate::{field_and_curve_elements::FiniteECPoint, json::*, v1::*};
 use mina_serialization_types_macros::AutoFrom;
 use serde::{Deserialize, Serialize};
-use versioned::Versioned;
+use versioned::{Versioned, Versioned2};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ProofMessages {
@@ -34,8 +34,7 @@ pub struct ProofMessagesJson {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ProofMessageWithoutDegreeBoundList(pub Vec<FiniteECPoint>);
 
-pub type ProofMessageWithoutDegreeBoundListV1 =
-    Versioned<Versioned<ProofMessageWithoutDegreeBoundList, 1>, 1>;
+pub type ProofMessageWithoutDegreeBoundListV1 = Versioned2<ProofMessageWithoutDegreeBoundList, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(ProofMessageWithoutDegreeBoundList)]

--- a/protocol/serialization-types/src/proof_messages.rs
+++ b/protocol/serialization-types/src/proof_messages.rs
@@ -34,7 +34,8 @@ pub struct ProofMessagesJson {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ProofMessageWithoutDegreeBoundList(pub Vec<FiniteECPoint>);
 
-pub type ProofMessageWithoutDegreeBoundListV1 = Versioned2<ProofMessageWithoutDegreeBoundList, 1, 1>;
+pub type ProofMessageWithoutDegreeBoundListV1 =
+    Versioned2<ProofMessageWithoutDegreeBoundList, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(ProofMessageWithoutDegreeBoundList)]

--- a/protocol/serialization-types/src/protocol_constants.rs
+++ b/protocol/serialization-types/src/protocol_constants.rs
@@ -6,7 +6,7 @@
 use mina_serialization_types_macros::AutoFrom;
 use serde::{Deserialize, Serialize};
 
-use versioned::Versioned;
+use versioned::Versioned2;
 
 use crate::{
     common::{U32Json, U64Json},
@@ -29,7 +29,7 @@ pub struct ProtocolConstants {
 }
 
 /// Constants that define the consensus parameters (v1)
-pub type ProtocolConstantsV1 = Versioned<Versioned<ProtocolConstants, 1>, 1>;
+pub type ProtocolConstantsV1 = Versioned2<ProtocolConstants, 1, 1>;
 
 /// Constants that define the consensus parameters (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/protocol_state.rs
+++ b/protocol/serialization-types/src/protocol_state.rs
@@ -18,7 +18,7 @@ pub struct ProtocolState {
 }
 
 /// This structure can be thought of like the block header. It contains the most essential information of a block (v1)
-pub type ProtocolStateV1 = Versioned<Versioned<ProtocolState, 1>, 1>;
+pub type ProtocolStateV1 = Versioned2<ProtocolState, 1, 1>;
 
 /// This structure can be thought of like the block header. It contains the most essential information of a block. (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/protocol_state_body.rs
+++ b/protocol/serialization-types/src/protocol_state_body.rs
@@ -22,7 +22,7 @@ pub struct ProtocolStateBody {
 }
 
 /// Body of the protocol state (v1)
-pub type ProtocolStateBodyV1 = Versioned<Versioned<ProtocolStateBody, 1>, 1>;
+pub type ProtocolStateBodyV1 = Versioned2<ProtocolStateBody, 1, 1>;
 
 /// Body of the protocol state (json)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]

--- a/protocol/serialization-types/src/protocol_state_proof.rs
+++ b/protocol/serialization-types/src/protocol_state_proof.rs
@@ -21,8 +21,7 @@ pub struct ProtocolStateProof {
 }
 
 /// SNARK proof of the protocol state at some point in time (v1)
-pub type ProtocolStateProofV1 =
-    Versioned<Versioned<Versioned<Versioned<ProtocolStateProof, 1>, 1>, 1>, 1>;
+pub type ProtocolStateProofV1 = Versioned4<ProtocolStateProof, 1, 1, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(ProtocolStateProof)]
@@ -71,7 +70,7 @@ pub struct ProofStatement {
     pub pass_through: PairingBasedV1,
 }
 
-pub type ProofStatementV1 = Versioned<Versioned<ProofStatement, 1>, 1>;
+pub type ProofStatementV1 = Versioned2<ProofStatement, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(ProofStatement)]
@@ -170,7 +169,7 @@ pub struct SpongeDigestBeforeEvaluations(
 );
 
 pub type SpongeDigestBeforeEvaluationsV1 =
-    Versioned<Versioned<SpongeDigestBeforeEvaluations, 1>, 1>;
+    Versioned2<SpongeDigestBeforeEvaluations, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(SpongeDigestBeforeEvaluations)]
@@ -238,7 +237,7 @@ pub struct Proof {
     pub openings: ProofOpeningsV1,
 }
 
-pub type ProofV1 = Versioned<Versioned<Proof, 1>, 1>;
+pub type ProofV1 = Versioned2<Proof, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(Proof)]

--- a/protocol/serialization-types/src/protocol_state_proof.rs
+++ b/protocol/serialization-types/src/protocol_state_proof.rs
@@ -168,8 +168,7 @@ pub struct SpongeDigestBeforeEvaluations(
     pub (),
 );
 
-pub type SpongeDigestBeforeEvaluationsV1 =
-    Versioned2<SpongeDigestBeforeEvaluations, 1, 1>;
+pub type SpongeDigestBeforeEvaluationsV1 = Versioned2<SpongeDigestBeforeEvaluations, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(SpongeDigestBeforeEvaluations)]

--- a/protocol/serialization-types/src/signatures.rs
+++ b/protocol/serialization-types/src/signatures.rs
@@ -10,7 +10,7 @@ use crate::{
 use mina_serialization_types_macros::AutoFrom;
 use proof_systems::mina_signer::CompressedPubKey;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use versioned::Versioned;
+use versioned::{Versioned, Versioned2};
 
 /// An EC point stored in compressed form containing only the x coordinate and one extra bit
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -62,7 +62,7 @@ impl<'de> Deserialize<'de> for PublicKeyJson {
 
 /// Public key (v1)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PublicKeyV1(pub Versioned<Versioned<CompressedCurvePoint, 1>, 1>);
+pub struct PublicKeyV1(pub Versioned2<CompressedCurvePoint, 1, 1>);
 
 /// Public key (v1) with an extra version byte
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -70,7 +70,7 @@ pub struct PublicKey2V1(pub Versioned<PublicKeyV1, 1>); // with an extra version
 
 /// Signature (v1)
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct SignatureV1(pub Versioned<Versioned<(FieldElement, InnerCurveScalar), 1>, 1>);
+pub struct SignatureV1(pub Versioned2<(FieldElement, InnerCurveScalar), 1, 1>);
 
 /// Signature (json)
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/protocol/serialization-types/src/snark_work.rs
+++ b/protocol/serialization-types/src/snark_work.rs
@@ -7,7 +7,7 @@
 use crate::{common::*, json::*, v1::*, *};
 use mina_serialization_types_macros::AutoFrom;
 use serde::{Deserialize, Serialize};
-use versioned::Versioned;
+use versioned::{Versioned, Versioned2};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TransactionSnarkWork {
@@ -88,7 +88,7 @@ pub struct Statement {
     pub sok_digest: ByteVecV1,
 }
 
-pub type StatementV1 = Versioned<Versioned<Statement, 1>, 1>;
+pub type StatementV1 = Versioned2<Statement, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(Statement)]
@@ -111,7 +111,7 @@ pub struct PendingCoinbaseStackState {
     pub target: PendingCoinbaseV1,
 }
 
-pub type PendingCoinbaseStackStateV1 = Versioned<Versioned<PendingCoinbaseStackState, 1>, 1>;
+pub type PendingCoinbaseStackStateV1 = Versioned2<PendingCoinbaseStackState, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(PendingCoinbaseStackState)]
@@ -128,7 +128,7 @@ pub struct PendingCoinbase {
     pub state_stack: StateStackV1,
 }
 
-pub type PendingCoinbaseV1 = Versioned<Versioned<PendingCoinbase, 1>, 1>;
+pub type PendingCoinbaseV1 = Versioned2<PendingCoinbase, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(PendingCoinbase)]
@@ -146,7 +146,7 @@ pub struct StateStack {
     pub curr: HashV1,
 }
 
-pub type StateStackV1 = Versioned<Versioned<StateStack, 1>, 1>;
+pub type StateStackV1 = Versioned2<StateStack, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(StateStack)]
@@ -172,7 +172,7 @@ pub struct FeeExcessJson {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct FeeExcessPair(pub FeeExcess, pub FeeExcess);
 
-pub type FeeExcessPairV1 = Versioned<Versioned<FeeExcessPair, 1>, 1>;
+pub type FeeExcessPairV1 = Versioned2<FeeExcessPair, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(FeeExcessPair)]

--- a/protocol/serialization-types/src/staged_ledger_diff.rs
+++ b/protocol/serialization-types/src/staged_ledger_diff.rs
@@ -48,7 +48,7 @@ pub struct StagedLedgerPreDiff {
     pub internal_command_balances: Vec<InternalCommandBalanceDataV1>,
 }
 
-pub type StagedLedgerPreDiffV1 = Versioned<Versioned<StagedLedgerPreDiff, 1>, 1>;
+pub type StagedLedgerPreDiffV1 = Versioned2<StagedLedgerPreDiff, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(StagedLedgerPreDiff)]
@@ -80,7 +80,7 @@ pub enum UserCommand {
     // FIXME: other variants are not covered by current test block
 }
 
-pub type UserCommandV1 = Versioned<Versioned<UserCommand, 1>, 1>;
+pub type UserCommandV1 = Versioned2<UserCommand, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 enum UserCommandJsonProxy {
@@ -104,7 +104,7 @@ pub struct SignedCommand {
     pub signature: SignatureV1,
 }
 
-pub type SignedCommandV1 = Versioned<Versioned<SignedCommand, 1>, 1>;
+pub type SignedCommandV1 = Versioned2<SignedCommand, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(SignedCommand)]
@@ -120,7 +120,7 @@ pub struct SignedCommandPayload {
     pub body: SignedCommandPayloadBodyV1,
 }
 
-pub type SignedCommandPayloadV1 = Versioned<Versioned<SignedCommandPayload, 1>, 1>;
+pub type SignedCommandPayloadV1 = Versioned2<SignedCommandPayload, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(SignedCommandPayload)]
@@ -139,8 +139,7 @@ pub struct SignedCommandPayloadCommon {
     pub memo: SignedCommandMemoV1,
 }
 
-pub type SignedCommandPayloadCommonV1 =
-    Versioned<Versioned<Versioned<SignedCommandPayloadCommon, 1>, 1>, 1>;
+pub type SignedCommandPayloadCommonV1 = Versioned3<SignedCommandPayloadCommon, 1, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(SignedCommandPayloadCommon)]
@@ -160,7 +159,7 @@ pub enum SignedCommandPayloadBody {
     // FIXME: other variants are not covered by current test block
 }
 
-pub type SignedCommandPayloadBodyV1 = Versioned<Versioned<SignedCommandPayloadBody, 1>, 1>;
+pub type SignedCommandPayloadBodyV1 = Versioned2<SignedCommandPayloadBody, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 enum SignedCommandPayloadBodyJsonProxy {
@@ -192,7 +191,7 @@ pub struct PaymentPayload {
     pub amount: AmountV1,
 }
 
-pub type PaymentPayloadV1 = Versioned<Versioned<PaymentPayload, 1>, 1>;
+pub type PaymentPayloadV1 = Versioned2<PaymentPayload, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(PaymentPayload)]
@@ -234,7 +233,7 @@ pub enum StakeDelegationJson {
 
 impl_mina_enum_json_serde!(StakeDelegationJson, StakeDelegationJsonProxy);
 
-pub type SignedCommandFeeTokenV1 = Versioned<Versioned<Versioned<u64, 1>, 1>, 1>;
+pub type SignedCommandFeeTokenV1 = Versioned3<u64, 1, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SignedCommandMemo(pub Vec<u8>);
@@ -273,7 +272,7 @@ impl<'de> Deserialize<'de> for SignedCommandMemoJson {
 }
 
 // FIXME: No test coverage yet
-pub type SnappCommand = Versioned<Versioned<(), 1>, 1>;
+pub type SnappCommand = Versioned2<(), 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum TransactionStatus {
@@ -498,7 +497,7 @@ pub struct CoinBaseFeeTransfer {
     pub fee: ExtendedU64_2,
 }
 
-pub type CoinBaseFeeTransferV1 = Versioned<Versioned<CoinBaseFeeTransfer, 1>, 1>;
+pub type CoinBaseFeeTransferV1 = Versioned2<CoinBaseFeeTransfer, 1, 1>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, AutoFrom)]
 #[auto_from(CoinBaseFeeTransfer)]

--- a/protocol/versioned/src/lib.rs
+++ b/protocol/versioned/src/lib.rs
@@ -29,14 +29,16 @@ pub struct Versioned<T, const V: u16> {
 pub type Versioned2<T, const MAJOR: u16, const MINOR: u16> = Versioned<Versioned<T, MINOR>, MAJOR>;
 
 /// A wrapper around version supporting Major, Minor, and Patch revisions
-pub type Versioned3<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16> = Versioned2<Versioned<T, PATCH>, MAJOR, MINOR>;
+pub type Versioned3<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16> =
+    Versioned2<Versioned<T, PATCH>, MAJOR, MINOR>;
 
 /// A wrapper around version supporting Major, Minor, Patch, and Revision revisions
-pub type Versioned4<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16, const REVISION: u16> = Versioned3<Versioned<T, REVISION>, MAJOR, MINOR, PATCH>;
+pub type Versioned4<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16, const REVISION: u16> =
+    Versioned3<Versioned<T, REVISION>, MAJOR, MINOR, PATCH>;
 
 impl<T, const V: u16> Default for Versioned<T, V>
-    where
-        T: Default,
+where
+    T: Default,
 {
     fn default() -> Self {
         Self {
@@ -93,9 +95,7 @@ impl<T, const V1: u16, const V2: u16> From<Versioned2<T, V1, V2>> for (T,) {
     }
 }
 
-impl<T, const V1: u16, const V2: u16, const V3: u16> From<T>
-for Versioned3<T, V1, V2, V3>
-{
+impl<T, const V1: u16, const V2: u16, const V3: u16> From<T> for Versioned3<T, V1, V2, V3> {
     #[inline]
     fn from(t: T) -> Self {
         let t: Versioned2<T, V2, V3> = t.into();
@@ -103,9 +103,7 @@ for Versioned3<T, V1, V2, V3>
     }
 }
 
-impl<T, const V1: u16, const V2: u16, const V3: u16>
-From<Versioned3<T, V1, V2, V3>> for (T,)
-{
+impl<T, const V1: u16, const V2: u16, const V3: u16> From<Versioned3<T, V1, V2, V3>> for (T,) {
     #[inline]
     fn from(t: Versioned3<T, V1, V2, V3>) -> Self {
         let (t,): (Versioned2<T, V2, V3>,) = t.into();
@@ -114,7 +112,7 @@ From<Versioned3<T, V1, V2, V3>> for (T,)
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16, const V4: u16> From<T>
-for Versioned4<T, V1, V2, V3, V4>
+    for Versioned4<T, V1, V2, V3, V4>
 {
     #[inline]
     fn from(t: T) -> Self {
@@ -124,7 +122,7 @@ for Versioned4<T, V1, V2, V3, V4>
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16, const V4: u16>
-From<Versioned4<T, V1, V2, V3, V4>> for (T,)
+    From<Versioned4<T, V1, V2, V3, V4>> for (T,)
 {
     #[inline]
     fn from(t: Versioned4<T, V1, V2, V3, V4>) -> Self {

--- a/protocol/versioned/src/lib.rs
+++ b/protocol/versioned/src/lib.rs
@@ -25,9 +25,18 @@ pub struct Versioned<T, const V: u16> {
     pub t: T,
 }
 
+/// A wrapper around version supporting Major and Minor revisions
+pub type Versioned2<T, const MAJOR: u16, const MINOR: u16> = Versioned<Versioned<T, MINOR>, MAJOR>;
+
+/// A wrapper around version supporting Major, Minor, and Patch revisions
+pub type Versioned3<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16> = Versioned2<Versioned<T, PATCH>, MAJOR, MINOR>;
+
+/// A wrapper around version supporting Major, Minor, Patch, and Revision revisions
+pub type Versioned4<T, const MAJOR: u16, const MINOR: u16, const PATCH: u16, const REVISION: u16> = Versioned3<Versioned<T, REVISION>, MAJOR, MINOR, PATCH>;
+
 impl<T, const V: u16> Default for Versioned<T, V>
-where
-    T: Default,
+    where
+        T: Default,
 {
     fn default() -> Self {
         Self {
@@ -68,58 +77,58 @@ impl<T, const V: u16> From<Versioned<T, V>> for (T,) {
     }
 }
 
-impl<T, const V1: u16, const V2: u16> From<T> for Versioned<Versioned<T, V1>, V2> {
+impl<T, const V1: u16, const V2: u16> From<T> for Versioned2<T, V1, V2> {
     #[inline]
     fn from(t: T) -> Self {
-        let t: Versioned<T, V1> = t.into();
+        let t: Versioned<T, V2> = t.into();
         t.into()
     }
 }
 
-impl<T, const V1: u16, const V2: u16> From<Versioned<Versioned<T, V1>, V2>> for (T,) {
+impl<T, const V1: u16, const V2: u16> From<Versioned2<T, V1, V2>> for (T,) {
     #[inline]
-    fn from(t: Versioned<Versioned<T, V1>, V2>) -> Self {
-        let (t,): (Versioned<T, V1>,) = t.into();
+    fn from(t: Versioned2<T, V1, V2>) -> Self {
+        let (t,): (Versioned<T, V2>,) = t.into();
         t.into()
     }
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16> From<T>
-    for Versioned<Versioned<Versioned<T, V1>, V2>, V3>
+for Versioned3<T, V1, V2, V3>
 {
     #[inline]
     fn from(t: T) -> Self {
-        let t: Versioned<Versioned<T, V1>, V2> = t.into();
+        let t: Versioned2<T, V2, V3> = t.into();
         t.into()
     }
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16>
-    From<Versioned<Versioned<Versioned<T, V1>, V2>, V3>> for (T,)
+From<Versioned3<T, V1, V2, V3>> for (T,)
 {
     #[inline]
-    fn from(t: Versioned<Versioned<Versioned<T, V1>, V2>, V3>) -> Self {
-        let (t,): (Versioned<Versioned<T, V1>, V2>,) = t.into();
+    fn from(t: Versioned3<T, V1, V2, V3>) -> Self {
+        let (t,): (Versioned2<T, V2, V3>,) = t.into();
         t.into()
     }
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16, const V4: u16> From<T>
-    for Versioned<Versioned<Versioned<Versioned<T, V1>, V2>, V3>, V4>
+for Versioned4<T, V1, V2, V3, V4>
 {
     #[inline]
     fn from(t: T) -> Self {
-        let t: Versioned<Versioned<Versioned<T, V1>, V2>, V3> = t.into();
+        let t: Versioned3<T, V2, V3, V4> = t.into();
         t.into()
     }
 }
 
 impl<T, const V1: u16, const V2: u16, const V3: u16, const V4: u16>
-    From<Versioned<Versioned<Versioned<Versioned<T, V1>, V2>, V3>, V4>> for (T,)
+From<Versioned4<T, V1, V2, V3, V4>> for (T,)
 {
     #[inline]
-    fn from(t: Versioned<Versioned<Versioned<Versioned<T, V1>, V2>, V3>, V4>) -> Self {
-        let (t,): (Versioned<Versioned<Versioned<T, V1>, V2>, V3>,) = t.into();
+    fn from(t: Versioned4<T, V1, V2, V3, V4>) -> Self {
+        let (t,): (Versioned3<T, V2, V3, V4>,) = t.into();
         t.into()
     }
 }


### PR DESCRIPTION
Code clarity is improved by removing unneeded nesting and reducing visual noise.

**Summary of changes**
Changes introduced in this pull request:
- Adds type definitions representing nested use of `Versioned`
- Replace nested `Versioned` with these type definitions

<!-- Thank you 🔥 -->